### PR TITLE
Proposed provisions for National Conference cancellation

### DIFF
--- a/amendments/provisions-for-national-conference-cancellation.md
+++ b/amendments/provisions-for-national-conference-cancellation.md
@@ -6,7 +6,7 @@ description: By GitHub user CollinSumrell
 
 ### Pull Requests
 
-- [Proposed provisions for National Conference cancellation \(1\)](https://github.com/tsadiscord/bylaw-amendments/pull/2)
+- [Proposed provisions for National Conference cancellation \(2\)](https://github.com/tsadiscord/bylaw-amendments/pull/2)
 
 {% hint style="info" %}
 

--- a/amendments/provisions-for-national-conference-cancellation.md
+++ b/amendments/provisions-for-national-conference-cancellation.md
@@ -1,0 +1,16 @@
+---
+description: By GitHub user CollinSumrell
+---
+
+# Provisions for National Conference Cancellation
+
+### Pull Requests
+
+- [Proposed provisions for National Conference cancellation \(1\)](https://github.com/tsadiscord/bylaw-amendments/pull/2)
+
+{% hint style="info" %}
+
+### If you have similar changes, add them to this amendment
+
+To make sure that there's not a lot of duplication between amendments, add your changes to this amendment if it is on a similar subject.
+{% endhint %}

--- a/articles/article-iv.-executive-committee.md
+++ b/articles/article-iv.-executive-committee.md
@@ -59,3 +59,13 @@ The special election shall be conducted after the winners of the general electio
 
 The special election shall not have any runoffs. The winner of the special election shall be the person with a plurality of the vote and will be announced immediately following the tabulation of the votes.
 
+### SECTION 11
+
+In the event that the National TSA Conference is cancelled, special rules are to be followed for national officer election:
+
+- TSA delegates will not have an opportunity to vote for national officers.
+- The credentials committee referenced in Section 4 of this article shall be charged with both reviewing and nominating candidates for office from three distinct pools of candidates.
+- Nominations made by the credentials committee shall be reviewed by the TSA, Inc., Board of Directors.
+- The first pool of candidates shall consist of those who have applied to be a national officer via the National TSA Officer Candidate Program. If there are not enough candidates to fill all officer positions that have applied via the National TSA Officer Candidate Program, or the credentials committee determines that there are not enough satisfactory candidates, the candidate pool shall open to the second pool of candidates.
+- The second pool of candidates shall consist of a group of willing state vice-presidents that are qualified for national office. If there are not enough candidates to fill all remaining officer positions, or the credentials committee determines that there are not enough satisfactory candidates, the candidate pool shall open to the third pool of candidates.
+- The third pool of candidates shall consist of a group of all other willing state officers that are qualified for national office. If there are not enough candidates to fill all remaining officer positions, or the credentials committee determines that there are not enough satisfactory candidates, the remaining positions shall be considered vacant and filled according to rules stipulated in Section 6 of this article.

--- a/articles/article-v.-meetings.md
+++ b/articles/article-v.-meetings.md
@@ -14,5 +14,5 @@ A majority of the registered voting delegates for the national conference shall 
 
 ### SECTION 4
 
-- In the event that there is a threat to the safety and stability of the conference or its attendees, the TSA, Inc., Board of Directors reserve the right to cancel or postpone the National TSA Conference.
-- The TSA, Inc., Board of Directors shall attempt to make any cancellations or postponements at least 90 days before the conference, but these Bylaws shall not go so far as to restrict the Board from responding to an emergency cancellation or postponement.
+- In the event that there is a threat to the safety or stability of the conference or its attendees, the TSA, Inc., Board of Directors reserves the right to cancel or postpone the National TSA Conference.
+- The TSA, Inc., Board of Directors shall attempt to make any cancellations or postponements at least 90 days before the conference, but these Bylaws shall not go so far as to restrict the Board from responding to any emergency that demands the cancellation or postponement of the conference.

--- a/articles/article-v.-meetings.md
+++ b/articles/article-v.-meetings.md
@@ -12,3 +12,7 @@ Each chartered delegation will be entitled to one vote for each state officer in
 
 A majority of the registered voting delegates for the national conference shall constitute a quorum.
 
+### SECTION 4
+
+- In the event that there is a threat to the safety and stability of the conference or its attendees, the TSA, Inc., Board of Directors reserve the right to cancel or postpone the National TSA Conference.
+- The TSA, Inc., Board of Directors shall attempt to make any cancellations or postponements at least 90 days before the conference, but these Bylaws shall not go so far as to restrict the Board from responding to an emergency cancellation or postponement.


### PR DESCRIPTION
These are some preliminary changes that I'm proposing for the cancellation of national conference. In this request, I've only included things that say that TSA reserves the right to cancel for the safety and stability of the conference and its attendees and that it should stick to a lead-time of 90 days for cancellations. I also included a procedure to get new national officers in the event of a cancellation.

These are by no means finalized and I welcome any criticism of the changes. They're not perfect but they're certainly a starting point.