### PR TITLE
Shorten lead time required for amendments

### DIFF
--- a/articles/article-xiii.-amendments.md
+++ b/articles/article-xiii.-amendments.md
@@ -1,9 +1,9 @@
 # Article XIII. Amendments
 
-* To amend these bylaws, the proposed amendment\(s\) must be submitted in writing or by email by the chartered delegation to the President of TSA, Inc. at least ninety \(90\) days prior to the annual meeting.
+* To amend these bylaws, the proposed amendment\(s\) must be submitted in writing or by email by the chartered delegation to the President of TSA, Inc. at least sixty \(60\) days prior to the annual meeting.
 * A Bylaws Committee of the Board of Directors of TSA, Inc. will review all proposed amendments. All approved amendments will be submitted to the chartered delegations and the National TSA officers by the president \(chairman\) of the Board of Directors of TSA, Inc. at least thirty \(30\) days prior to the annual meeting.
 * The proposed amendment must be approved by two-thirds of the voting delegates present and voting at the annual meeting.
 * Each chartered delegation will be entitled to one vote for each state officer in attendance {maximum of six \(6\)} plus two additional votes for each chapter in that state delegation which has student members in attendance at the conference.
-* The president \(chairman\) of the Board of Directors of TSA, Inc. will be responsible for notifying in writing or by email to the Corporate Board member and State Advisor of the chartered delegations of adopted amendments within sixty \(60\) days of the annual meeting.
+* The president \(chairman\) of the Board of Directors of TSA, Inc. will be responsible for notifying in writing or by email to the Corporate Board member and State Advisor of the chartered delegations of adopted amendments within thirty \(30\) days of the annual meeting.
 * Amendments will become effective in sixty \(60\) days unless a different time period is stipulated in the amendment.
 


### PR DESCRIPTION
This proposal shortens the lead time of Bylaw amendments from 90 days to 60 days, and changes the notification of chartered delegations deadline from 60 days to 30 days to compensate.