### PR TITLE
Recount delegates every 2 hours to ensure a quorum is met

### DIFF
--- a/articles/article-iv.-executive-committee.md
+++ b/articles/article-iv.-executive-committee.md
@@ -1,10 +1,10 @@
 # Article IV. Executive Committee
 
-## SECTION 1
+### SECTION 1
 
 The National TSA officers shall consist of a president, vice-president, secretary, treasurer, sergeant-at-arms, and reporter. No individual may serve more than one term as a national officer in the same office. These officers and the National TSA advisor\(s\) will be known collectively as the Executive Committee of TSA.
 
-## SECTION 2
+### SECTION 2
 
 * President: It shall be the duty of the president of TSA to preside at all meetings; to make necessary committee appointments including the designation of a committee chairperson; to develop with the Executive Committee a program of work for the term of office; and to be available, as necessary, in promoting the general welfare of TSA.
 * Vice-President: It shall be the duty of the vice-president to serve in any capacity as directed by the president; to accept the responsibility of the president as occasion may demand; to serve as chairperson of the TSA Council of State Presidents; and to be available, as necessary, in promoting the general welfare of TSA.
@@ -13,20 +13,20 @@ The National TSA officers shall consist of a president, vice-president, secretar
 * Sergeant-at-Arms: It shall be the duty of the sergeant-at-arms to serve in any capacity as directed by the president; to assist in the preparation and control of the meeting place, in the event that a parliamentarian is not appointed by the president; to assist in conducting all meetings according to parliamentary procedure as set forth by the current edition of Robert's Rules of Order, Newly Revised; and to be available, as necessary, in promoting the general welfare of TSA.
 * Reporter: It shall be the duty of the reporter to serve in any capacity as directed by the president; to accumulate and keep up-to-date information on the history of the association; to prepare \# ARTICLEs for TSA publications, professional magazines and journals, newspapers and other news media; to contact other association members concerning news items for publication; and to be available, as necessary, in promoting the general welfare of TSA.
 
-## SECTION 3
+### SECTION 3
 
 QUALIFICATIONS FOR NATIONAL OFFICE
 
 * Only an active member of TSA will be eligible to run for a national office. Students must have at least one year of high school eligibility remaining to run for national office. A student elected as a national officer at the annual meeting may not hold a state or local TSA office concurrently with the term as national officer.
 * A student must be a member of TSA for at least one year before seeking a national office. A TSA member must have completed the eighth grade to be qualified for a national office. A TSA member must have served as an officer of the individual's state association to be qualified as a national officer candidate. No more than three TSA members from the same state delegation may run for a national office in the same year.
 
-## SECTION 4
+### SECTION 4
 
 NOMINATIONS
 
 * The National TSA president shall appoint a credentials committee consisting of a national advisor; a national officer not seeking re-election; a state president who, while serving on this committee, has no national officers or national officer candidates from the individual's state; a past national officer; and the executive director of TSA. This committee shall review all national officer candidates and their qualifications and will submit to the voting delegates a slate of all candidates declared eligible for each national office. There will be no additional nominations from the floor.
 
-## SECTION 5
+### SECTION 5
 
 ELECTIONS
 
@@ -35,31 +35,29 @@ ELECTIONS
 * If there are more than two candidates for an office and a majority is not reached on the first ballot, the candidate receiving the lowest number of votes shall be dropped, and the candidate receiving the lowest number of votes on each succeeding ballot will be dropped until a majority is reached.
 * If there is only one candidate for an office, the candidate must receive at least two-thirds \(2/3\) of the total votes from the votes cast. In this type of election, delegates may vote “Yes”, “No”, or may abstain. To be elected, an unopposed candidate must receive an affirmative two-thirds \(2/3\) vote from the total number of votes cast for that candidate by the delegates.
 
-## SECTION 6
+### SECTION 6
 
 The TSA Executive Committee may fill by appointment any vacancy occurring among the national officers for the unexpired term except the office of president, which shall be filled by the vice-president.
 
-## SECTION 7
+### SECTION 7
 
 National officers' terms will begin at the close of the national conference at which they are elected, and they will serve until the close of the following national conference.
 
-## SECTION 8
+### SECTION 8
 
 Failure to fulfill the obligations of a national office without legitimate cause will result in the removal from office by the TSA, Inc., Board of Directors.
 
-## SECTION 9
+### SECTION 9
 
 If no one applies for a particular office by the official deadline date for a national officer candidate application or an unopposed candidate does not receive a two-thirds \(2/3\) majority, there shall be a special election called after the general election takes place at the annual business meeting.
 
-## SECTION 10
+### SECTION 10
 
-Those National Officer Candidates not elected to a National Office at the annual business meeting shall be the only members to be able to participate in the special election, however are not required to.
+* Those National Officer Candidates not elected to a National Office at the annual business meeting shall be the only members to be able to participate in the special election, however are not required to.
+* The special election shall be conducted after the winners of the general election have been announced. The participants of the special election may not campaign prior to the special election.
+* The special election shall not have any runoffs. The winner of the special election shall be the person with a plurality of the vote and will be announced immediately following the tabulation of the votes.
 
-The special election shall be conducted after the winners of the general election have been announced. The participants of the special election may not campaign prior to the special election.
-
-The special election shall not have any runoffs. The winner of the special election shall be the person with a plurality of the vote and will be announced immediately following the tabulation of the votes.
-
-## SECTION 11
+### SECTION 11
 
 In the event that the National TSA Conference is cancelled, special rules are to be followed for national officer election:
 

--- a/articles/article-v.-meetings.md
+++ b/articles/article-v.-meetings.md
@@ -1,19 +1,23 @@
 # Article V. Meetings
 
-## SECTION 1
+### SECTION 1
 
 A National TSA Conference will be held each year with the time, date, and place designated by the TSA, Inc., Board of Directors.
 
-## SECTION 2
+### SECTION 2
 
 Each chartered delegation will be entitled to one vote for each state officer in attendance {maximum of six \(6\)} plus two additional votes for each chapter in that state delegation which has student members in attendance at the conference.
 
-## SECTION 3
+### SECTION 3
 
 A majority of the registered voting delegates for the national conference shall constitute a quorum.
 
-## SECTION 4
+### SECTION 4
+
+A recount of voting delegates shall be conducted every one hundred and twenty (120) minutes to ensure that a quorum is actively being met.
+
+### SECTION 5
 
 * In the event that there is a threat to the safety or stability of the conference or its attendees, the TSA, Inc., Board of Directors reserves the right to cancel or postpone the National TSA Conference.
-* The TSA, Inc., Board of Directors shall attempt to make any cancellations or postponements at least 90 days before the conference, but these Bylaws shall not go so far as to restrict the Board from responding to any emergency that demands the cancellation or postponement of the conference.
+* The TSA, Inc., Board of Directors shall attempt to make any cancellations or postponements at least ninety (90) days before the conference, but these Bylaws shall not go so far as to restrict the Board from responding to any emergency that demands the cancellation or postponement of the conference.
 


### PR DESCRIPTION
At national conference, the business meeting can run quite long and interfere with some events. To protect members from having a minority of the registered voting delegates control the future of the organization.

The two-hour interval was chosen because it's long enough not to interfere too much, but short enough to do its job of recounting people before too many decisions are made without a quorum.